### PR TITLE
LeftCoefficientField & RightCoefficientField schema change from decimal to string

### DIFF
--- a/src/QRev/Schema/QRev.cs
+++ b/src/QRev/Schema/QRev.cs
@@ -3974,7 +3974,7 @@ namespace QRev.Schema {
         
         private string typeField;
         
-        private decimal valueField;
+        private string valueField;
         
         /// <remarks/>
         [System.Xml.Serialization.XmlAttributeAttribute()]
@@ -3989,7 +3989,7 @@ namespace QRev.Schema {
         
         /// <remarks/>
         [System.Xml.Serialization.XmlTextAttribute()]
-        public decimal Value {
+        public string Value {
             get {
                 return this.valueField;
             }
@@ -4044,7 +4044,7 @@ namespace QRev.Schema {
         
         private string typeField;
         
-        private decimal valueField;
+        private string valueField;
         
         /// <remarks/>
         [System.Xml.Serialization.XmlAttributeAttribute()]
@@ -4059,7 +4059,7 @@ namespace QRev.Schema {
         
         /// <remarks/>
         [System.Xml.Serialization.XmlTextAttribute()]
-        public decimal Value {
+        public string Value {
             get {
                 return this.valueField;
             }
@@ -5300,7 +5300,7 @@ namespace QRev.Schema {
         
         private string typeField;
         
-        private decimal valueField;
+        private string valueField;
         
         /// <remarks/>
         [System.Xml.Serialization.XmlAttributeAttribute()]
@@ -5315,7 +5315,7 @@ namespace QRev.Schema {
         
         /// <remarks/>
         [System.Xml.Serialization.XmlTextAttribute()]
-        public decimal Value {
+        public string Value {
             get {
                 return this.valueField;
             }
@@ -5453,7 +5453,7 @@ namespace QRev.Schema {
         
         private string typeField;
         
-        private decimal valueField;
+        private string valueField;
         
         /// <remarks/>
         [System.Xml.Serialization.XmlAttributeAttribute()]
@@ -5468,7 +5468,7 @@ namespace QRev.Schema {
         
         /// <remarks/>
         [System.Xml.Serialization.XmlTextAttribute()]
-        public decimal Value {
+        public string Value {
             get {
                 return this.valueField;
             }

--- a/src/QRev/Schema/QRev.xsd
+++ b/src/QRev/Schema/QRev.xsd
@@ -723,7 +723,7 @@
                     <xs:element name="LeftEdgeCoefficient">
                       <xs:complexType>
                         <xs:simpleContent>
-                          <xs:extension base="xs:decimal">
+                          <xs:extension base="xs:string">
                             <xs:attribute name="type" type="xs:string" use="required" />
                           </xs:extension>
                         </xs:simpleContent>
@@ -741,7 +741,7 @@
                     <xs:element name="RightEdgeCoefficient">
                       <xs:complexType>
                         <xs:simpleContent>
-                          <xs:extension base="xs:decimal">
+                          <xs:extension base="xs:string">
                             <xs:attribute name="type" type="xs:string" use="required" />
                           </xs:extension>
                         </xs:simpleContent>
@@ -968,7 +968,7 @@
                     <xs:element name="LeftEdgeCoefficient">
                       <xs:complexType>
                         <xs:simpleContent>
-                          <xs:extension base="xs:decimal">
+                          <xs:extension base="xs:string">
                             <xs:attribute name="type" type="xs:string" use="required" />
                           </xs:extension>
                         </xs:simpleContent>
@@ -1005,7 +1005,7 @@
                     <xs:element name="RightEdgeCoefficient">
                       <xs:complexType>
                         <xs:simpleContent>
-                          <xs:extension base="xs:decimal">
+                          <xs:extension base="xs:string">
                             <xs:attribute name="type" type="xs:string" use="required" />
                           </xs:extension>
                         </xs:simpleContent>


### PR DESCRIPTION
Decided on a simple hack of changing the schema from a decimal to string.  These fields dont appear to be used by the plugin , and its just a case of those fields preventing the xml file from being deserialized.

I think the driver will need more work over time to make it more flexible.  If fields can change type a rigid xsd will not suffice.